### PR TITLE
Allow writing to loop device

### DIFF
--- a/fedora-installer
+++ b/fedora-installer
@@ -443,9 +443,11 @@ if [[ "$SDTYP" = "sd" ]]; then
 	SDDEV=""
 elif [[ "$SDTYP" = "mm" ]]; then
 	SDDEV="p"
-else 
-	clear
-	exit 1
+elif [[ "$SDTYP" = "lo" ]]; then
+	SDDEV="p"
+else
+  clear
+  exit 1
 fi
 
 


### PR DESCRIPTION
This allow you to write the result to a loop device backed by a file. Creating an image that you can later dd to an sd card / emmc

```
fallocate -l 10GiB myimage.img
losetup /dev/loopX myimage.img
```
Run the script pointing to `/dev/loopX`